### PR TITLE
fix(nodeApp): apostrophe used instead of back ticks for console log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitOps with Tekton and ArgoCD
 ## Simple Node JS App Soup to Nuts: From DeskTop Docker to OpenShift Cluster
 
-This git repo is a simple contains a simple node applicaiton that uses argocd to deploy its tekton pipeline to OpenSHift 4.3.  It the uses Tekton to build an image, publish it to the Container Registry and executes an argo sync to deploy the app.  
+This git repo contains a simple node applicaiton that uses argocd to deploy its tekton pipeline to OpenSHift 4.3.  It the uses Tekton to build an image, publish it to the Container Registry and executes an argo sync to deploy the app.  
 
 ![alt argo-flow-1](images/TektonArgoOpenShift.png)
 

--- a/server.js
+++ b/server.js
@@ -11,8 +11,8 @@ const VERSION = process.env.VERSION || "0.0";
 // App
 const app = express();
 app.get('/', (req, res) => {
-  res.send('Hello RBC !!!!!!!  VERSION ${VERSION} ');
+  res.send(`Hello RBC !!!!!!!  VERSION ${VERSION} `);
 });
 
 app.listen(PORT, HOST);
-console.log('Running on http://${HOST}:${PORT}');
+console.log(`Running on http://${HOST}:${PORT}`);


### PR DESCRIPTION
Apostrophe was used instead of back ticks for console log and result in server.js, this resulted in the application outputting `Hello RBC !!!!!!!  VERSION ${VERSION}` instead of `Hello RBC !!!!!!!  VERSION 0.0`

Also updated the readme intro